### PR TITLE
Fix `.tool-versions` Java version

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-java latest:zulu-17
+java zulu-17.50.19


### PR DESCRIPTION
I made a mistake in 29e6994; you [can’t use `latest` in `.tool-versions`](https://asdf-vm.com/manage/configuration.html#tool-versions).